### PR TITLE
Install from tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+pyepsg.py
+README.rst
+COPYING.LESSER
+COPYING

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with pyepsg.  If not, see <http://www.gnu.org/licenses/>.
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='pyepsg',


### PR DESCRIPTION
The tarball at PyPI tries to read the `README.rst` file, but that file is not included in the archive. Not sure if this PR is the best way to fix this.