### PR TITLE
Use bytes for XML parsing instead of decoded text.

### DIFF
--- a/pyepsg.py
+++ b/pyepsg.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014, Met Office
+# (C) British Crown Copyright 2014 - 2016, Met Office
 #
 # This file is part of pyepsg.
 #
@@ -200,8 +200,8 @@ class CRS(EPSG):
         domain_href = domain.attrib[XLINK_NS + 'href']
         url = '{prefix}{code}.gml?download'.format(prefix=EPSG_IO_URL,
                                                    code=domain_href)
-        xml = requests.get(url).text
-        gml = ET.fromstring(xml.encode('UTF-8'))
+        xml = requests.get(url).content
+        gml = ET.fromstring(xml)
 
         def extract_bound(i, tag):
             # TODO: Figure out if this is our problem or ET's.
@@ -272,7 +272,7 @@ def get(code):
     if instance is None:
         url = '{prefix}{code}.gml?download'.format(prefix=EPSG_IO_URL,
                                                    code=code)
-        xml = requests.get(url).text
+        xml = requests.get(url).content
         root = ET.fromstring(xml)
         class_for_tag = {
             GML_NS + 'CartesianCS': CartesianCS,


### PR DESCRIPTION
XML should contain its encoding and lxml prefers getting bytes that it can decode itself.

Fixes a couple exceptions in the tests:

``` pytb
Trying:
    print(get(21781).as_proj4())
Expecting:
    +proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel +towgs84=674.4,15.1,405.3,0,0,0,0 +units=m +no_defs
**********************************************************************
File "/home/elliott/.local/lib/python2.7/site-packages/pyepsg.py", line 160, in __main__.CRS.as_proj4
Failed example:
    print(get(21781).as_proj4())
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib64/python2.7/doctest.py", line 1315, in __run
        compileflags, 1) in test.globs
      File "<doctest __main__.CRS.as_proj4[0]>", line 1, in <module>
        print(get(21781).as_proj4())
      File "/home/elliott/.local/lib/python2.7/site-packages/pyepsg.py", line 276, in get
        root = ET.fromstring(xml)
      File "/usr/lib64/python2.7/xml/etree/ElementTree.py", line 1300, in XML
        parser.feed(text)
      File "/usr/lib64/python2.7/xml/etree/ElementTree.py", line 1640, in feed
        self._parser.Parse(data, 0)
    UnicodeEncodeError: 'ascii' codec can't encode characters in position 839-840: ordinal not in range(128)
```

and

``` pytb
Trying:
    print(get(21781).domain_of_validity())
Expecting:
    [5.97, 10.49, 45.83, 47.81]
**********************************************************************
File "/home/elliott/.local/lib/python2.7/site-packages/pyepsg.py", line 191, in __main__.CRS.domain_of_validity
Failed example:
    print(get(21781).domain_of_validity())
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib64/python2.7/doctest.py", line 1315, in __run
        compileflags, 1) in test.globs
      File "<doctest __main__.CRS.domain_of_validity[0]>", line 1, in <module>
        print(get(21781).domain_of_validity())
      File "/home/elliott/.local/lib/python2.7/site-packages/pyepsg.py", line 276, in get
        root = ET.fromstring(xml)
      File "/usr/lib64/python2.7/xml/etree/ElementTree.py", line 1300, in XML
        parser.feed(text)
      File "/usr/lib64/python2.7/xml/etree/ElementTree.py", line 1640, in feed
        self._parser.Parse(data, 0)
    UnicodeEncodeError: 'ascii' codec can't encode characters in position 839-840: ordinal not in range(128)
```
