### PR TITLE
Fix domain of validity XML searching

### DIFF
--- a/pyepsg.py
+++ b/pyepsg.py
@@ -189,7 +189,7 @@ class CRS(EPSG):
         For example::
 
             >>> print(get(21781).domain_of_validity())
-            [5.97, 10.49, 45.83, 47.81]
+            [5.96, 10.49, 45.82, 47.81]
 
 
         """

--- a/pyepsg.py
+++ b/pyepsg.py
@@ -193,7 +193,6 @@ class CRS(EPSG):
 
 
         """
-        # TODO: Check for gmd:EX_GeographicBoundingBox and blow up otherwise.
         # TODO: Generalise interface to return a polygon? (Can we find
         # something that uses a polygon instead?)
         domain = self.element.find(GML_NS + 'domainOfValidity')
@@ -203,17 +202,17 @@ class CRS(EPSG):
         xml = requests.get(url).text
         gml = ET.fromstring(xml.encode('UTF-8'))
 
-        def extract_bound(i, tag):
-            # TODO: Figure out if this is our problem or ET's.
-            # `find` isn't returning anything :(
-            # ns = '{http://www.isotc211.org/2005/gmd}'
-            # bound = gml.find(ns + tag)
-            bound = gml[1][0][1][0][i]
-            return float(bound[0].text)
+        def extract_bound(tag):
+            ns = '{http://www.isotc211.org/2005/gmd}'
+            xpath = './/{ns}EX_GeographicBoundingBox/{ns}{tag}/'.format(
+                ns=ns,
+                tag=tag)
+            bound = gml.find(xpath)
+            return float(bound.text)
 
         tags = ('westBoundLongitude', 'eastBoundLongitude',
                 'southBoundLatitude', 'northBoundLatitude')
-        bounds = [extract_bound(i, tag) for i, tag in enumerate(tags)]
+        bounds = [extract_bound(tag) for tag in tags]
         return bounds
 
 


### PR DESCRIPTION
The commented code references `Element.find` not working, but that's because it only finds direct children. Using XPath allows to find any deep child which is what's required.
