### PR TITLE
Enhance cache strategy to avoid network calls

### DIFF
--- a/pyepsg.py
+++ b/pyepsg.py
@@ -34,6 +34,8 @@ GML_NS = '{http://www.opengis.net/gml/3.2}'
 XLINK_NS = '{http://www.w3.org/1999/xlink}'
 
 
+_cache_html = {}
+_cache_wkt = {}
 _cache_gml = {}
 _cache_proj4 = {}
 
@@ -134,9 +136,13 @@ class CRS(EPSG):
             PROJCS["OSGB_1936_British_National_Grid",GEOGCS["GCS_OSGB 19...
 
         """
-        url = '{prefix}{code}.esriwkt?download'.format(prefix=EPSG_IO_URL,
-                                                       code=self.id)
-        return requests.get(url).text
+        result = _cache_wkt.get(self.id)
+        if result is None:
+            url = '{prefix}{code}.esriwkt?download'.format(prefix=EPSG_IO_URL,
+                                                        code=self.id)
+            result = requests.get(url).text
+            _cache_wkt[self.id] = result
+        return result
 
     def as_html(self):
         """
@@ -148,9 +154,13 @@ class CRS(EPSG):
             <div class="syntax"><pre><span class="gh">PROJCS</span><span...
 
         """
-        url = '{prefix}{code}.html?download'.format(prefix=EPSG_IO_URL,
-                                                    code=self.id)
-        return requests.get(url).text
+        result = _cache_html.get(self.id)
+        if result is None:
+            url = '{prefix}{code}.html?download'.format(prefix=EPSG_IO_URL,
+                                                        code=self.id)
+            result = requests.get(url).text
+            _cache_html[self.id] = result
+        return result
 
     def as_proj4(self):
         """
@@ -185,9 +195,13 @@ class CRS(EPSG):
             PROJCS["OSGB 1936 / British National Grid",GEOGCS["OSGB 1936...
 
         """
-        url = '{prefix}{code}.wkt?download'.format(prefix=EPSG_IO_URL,
-                                                   code=self.id)
-        return requests.get(url).text
+        result = _cache_wkt.get(self.id)
+        if result is None:
+            url = '{prefix}{code}.wkt?download'.format(prefix=EPSG_IO_URL,
+                                                    code=self.id)
+            result = requests.get(url).text
+            _cache_wkt[self.id] = result
+        return result
 
     def domain_of_validity(self):
         """

--- a/pyepsg.py
+++ b/pyepsg.py
@@ -35,6 +35,7 @@ XLINK_NS = '{http://www.w3.org/1999/xlink}'
 
 
 _cache_html = {}
+_cache_esriwkt = {}
 _cache_wkt = {}
 _cache_gml = {}
 _cache_proj4 = {}
@@ -136,12 +137,12 @@ class CRS(EPSG):
             PROJCS["OSGB_1936_British_National_Grid",GEOGCS["GCS_OSGB 19...
 
         """
-        result = _cache_wkt.get(self.id)
+        result = _cache_esriwkt.get(self.id)
         if result is None:
             url = '{prefix}{code}.esriwkt?download'.format(prefix=EPSG_IO_URL,
                                                         code=self.id)
             result = requests.get(url).text
-            _cache_wkt[self.id] = result
+            _cache_esriwkt[self.id] = result
         return result
 
     def as_html(self):

--- a/pyepsg.py
+++ b/pyepsg.py
@@ -205,9 +205,14 @@ class CRS(EPSG):
         # something that uses a polygon instead?)
         domain = self.element.find(GML_NS + 'domainOfValidity')
         domain_href = domain.attrib[XLINK_NS + 'href']
-        url = '{prefix}{code}.gml?download'.format(prefix=EPSG_IO_URL,
-                                                   code=domain_href)
-        xml = requests.get(url).content
+
+        xml = _cache_gml.get(domain_href)
+        if xml is None:
+            url = '{prefix}{code}.gml?download'.format(prefix=EPSG_IO_URL,
+                                                    code=domain_href)
+            xml = requests.get(url).content
+            _cache_gml[domain_href] = xml
+
         gml = ET.fromstring(xml)
 
         def extract_bound(tag):

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup
 
 setup(
     name='pyepsg',
-    version='0.4.0',
+    version='0.5.0',
     url='https://github.com/rhattersley/pyepsg',
     author='Richard Hattersley',
     author_email='rhattersley@gmail.com',


### PR DESCRIPTION
WeakRef was not working properly on my case, so I changed the strategy to use plain dict. 
A memory leak is not meant to happen because we will have few different codes over time.

There were added caching to calls to wkt, html and gml services