### PR TITLE
Use HTTPS (where available)

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -645,7 +645,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -664,11 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/COPYING.LESSER
+++ b/COPYING.LESSER
@@ -1,7 +1,7 @@
                    GNU LESSER GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ pyepsg
 |build_status|
 
 
-A simple interface to http://epsg.io/
+A simple interface to https://epsg.io/
 
 For example, we can request the details for the projected coordinate system
 identified by EPSG code 21781, aka. "Swiss CH1903 / LV03"::
@@ -27,4 +27,4 @@ other forms::
 
 .. |build_status| image:: https://secure.travis-ci.org/rhattersley/pyepsg.png
    :alt: Build Status
-   :target: http://travis-ci.org/rhattersley/pyepsg
+   :target: https://travis-ci.org/rhattersley/pyepsg

--- a/pyepsg.py
+++ b/pyepsg.py
@@ -13,9 +13,9 @@
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with pyepsg.  If not, see <http://www.gnu.org/licenses/>.
+# along with pyepsg.  If not, see <https://www.gnu.org/licenses/>.
 """
-Provides simple access to http://epsg.io/.
+Provides simple access to https://epsg.io/.
 
 The entry point for this package is the :func:`get()` function.
 
@@ -29,7 +29,7 @@ import xml.etree.ElementTree as ET
 import requests
 
 
-EPSG_IO_URL = 'http://epsg.io/'
+EPSG_IO_URL = 'https://epsg.io/'
 
 GML_NS = '{http://www.opengis.net/gml/3.2}'
 XLINK_NS = '{http://www.w3.org/1999/xlink}'

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with pyepsg.  If not, see <http://www.gnu.org/licenses/>.
+# along with pyepsg.  If not, see <https://www.gnu.org/licenses/>.
 
 from setuptools import setup
 
@@ -31,7 +31,7 @@ setup(
                  'Programming Language :: Python :: 3.3',
                  'Programming Language :: Python :: 3.4',
                  'Topic :: Scientific/Engineering :: GIS'],
-    description='Easy access to the EPSG database via http://epsg.io/',
+    description='Easy access to the EPSG database via https://epsg.io/',
     long_description=open('README.rst').read(),
     install_requires=['requests'],
     py_modules=['pyepsg'],


### PR DESCRIPTION
Most of these links redirect to HTTPS anyways, but it's simpler to specify HTTPS in the URL.

XML namespaces are left alone.